### PR TITLE
allow different debounce times for different input types

### DIFF
--- a/Firmware/USMArduinoFirmware/USMArduinoFirmware.ino
+++ b/Firmware/USMArduinoFirmware/USMArduinoFirmware.ino
@@ -81,7 +81,7 @@
 */
 
 /*--------------------------- Version ------------------------------------*/
-#define VERSION "4.6"
+#define VERSION "4.7"
 
 /*--------------------------- Configuration ------------------------------*/
 // Should be no user configuration in this file, everything should be in;

--- a/Firmware/USMArduinoFirmware/USM_Input.cpp
+++ b/Firmware/USMArduinoFirmware/USM_Input.cpp
@@ -1,7 +1,7 @@
 /*
  * USM_Input.cpp
  * 
- * An Arduino library capable of detecting input events and reporing
+ * An Arduino library capable of detecting input events and reporting
  * consecutive button presses made in quick succession or if the 
  * button was held down for a long time. 
  *
@@ -99,25 +99,27 @@ uint8_t USM_Input::_getValue(uint16_t value, uint8_t input)
 
 uint16_t USM_Input::_getDebounceLowTime(uint8_t type)
 {
-  if (type == BUTTON)
+  switch (type)
   {
-    return USM_BTN_DEBOUNCE_LOW_MS;
-  }
-  else
-  {
-    return USM_OTH_DEBOUNCE_LOW_MS;
+    case BUTTON:
+      return USM_BTN_DEBOUNCE_LOW_MS;
+    case ROTARY:
+      return USM_ROT_DEBOUNCE_LOW_MS;
+    default:
+      return USM_OTH_DEBOUNCE_LOW_MS;
   }
 }
 
 uint16_t USM_Input::_getDebounceHighTime(uint8_t type)
 {
-  if (type == BUTTON)
+  switch (type)
   {
-    return USM_BTN_DEBOUNCE_HIGH_MS;
-  }
-  else
-  {
-    return USM_OTH_DEBOUNCE_HIGH_MS;
+    case BUTTON:
+      return USM_BTN_DEBOUNCE_HIGH_MS;
+    case ROTARY:
+      return USM_ROT_DEBOUNCE_HIGH_MS;
+    default:
+      return USM_OTH_DEBOUNCE_HIGH_MS;
   }
 }
 

--- a/Firmware/USMArduinoFirmware/USM_Input.cpp
+++ b/Firmware/USMArduinoFirmware/USM_Input.cpp
@@ -97,6 +97,30 @@ uint8_t USM_Input::_getValue(uint16_t value, uint8_t input)
   return bit;
 }
 
+uint16_t USM_Input::_getDebounceLowTime(uint8_t type)
+{
+  if (type == BUTTON)
+  {
+    return USM_BTN_DEBOUNCE_LOW_MS;
+  }
+  else
+  {
+    return USM_OTH_DEBOUNCE_LOW_MS;
+  }
+}
+
+uint16_t USM_Input::_getDebounceHighTime(uint8_t type)
+{
+  if (type == BUTTON)
+  {
+    return USM_BTN_DEBOUNCE_HIGH_MS;
+  }
+  else
+  {
+    return USM_OTH_DEBOUNCE_HIGH_MS;
+  }
+}
+
 void USM_Input::_update(uint8_t event[], uint16_t value) 
 {
   // Work out how long since our last update so we can increment the event times for each button
@@ -163,7 +187,7 @@ void USM_Input::_update(uint8_t event[], uint16_t value)
           _usmState[i].data.state = IS_HIGH;
           _eventTime[i] = 0;
         }
-        else if (_eventTime[i] > USM_DEBOUNCE_LOW_TIME) 
+        else if (_eventTime[i] > _getDebounceLowTime(type)) 
         {
           _usmState[i].data.state = IS_LOW;
           _eventTime[i] = 0;
@@ -185,7 +209,7 @@ void USM_Input::_update(uint8_t event[], uint16_t value)
         }
         else
         {
-          if (type == BUTTON && _eventTime[i] > USM_HOLD_TIME) 
+          if (type == BUTTON && _eventTime[i] > USM_BTN_HOLD_MS) 
           {
             _usmState[i].data.clicks = USM_HOLD_EVENT;
             _eventTime[i] = 0;
@@ -202,7 +226,7 @@ void USM_Input::_update(uint8_t event[], uint16_t value)
           _usmState[i].data.state = IS_LOW;
           _eventTime[i] = 0;
         }
-        else if (_eventTime[i] > USM_DEBOUNCE_HIGH_TIME) 
+        else if (_eventTime[i] > _getDebounceHighTime(type)) 
         {
           // for CONTACT, SWITCH or TOGGLE inputs send an event since we have transitioned
           // otherwise check if we have been holding or increment the click count
@@ -220,14 +244,14 @@ void USM_Input::_update(uint8_t event[], uint16_t value)
             } 
             else 
             {
-              _usmState[i].data.clicks = min(USM_MAX_CLICKS, _usmState[i].data.clicks + 1);
+              _usmState[i].data.clicks = min(USM_BTN_MAX_CLICKS, _usmState[i].data.clicks + 1);
               _usmState[i].data.state = AWAIT_MULTI;
               _eventTime[i] = 0; 
             }
           }
         }  
       } 
-      // AWAIT_MULTI
+      // AWAIT_MULTI (can only be here for BUTTON inputs)
       else if (_usmState[i].data.state == AWAIT_MULTI) 
       { 
         if (_getValue(value, i) == LOW) 
@@ -235,7 +259,7 @@ void USM_Input::_update(uint8_t event[], uint16_t value)
           _usmState[i].data.state = DEBOUNCE_LOW;
           _eventTime[i] = 0;
         } 
-        else if (_eventTime[i] > USM_MULTI_CLICK_TIME) 
+        else if (_eventTime[i] > USM_BTN_MULTI_CLICK_MS) 
         {
           _usmState[i].data.state = IS_HIGH;
           event[i] = _usmState[i].data.clicks;

--- a/Firmware/USMArduinoFirmware/USM_Input.h
+++ b/Firmware/USMArduinoFirmware/USM_Input.h
@@ -1,7 +1,7 @@
 /*
  * USM_Input.h
  * 
- * An Arduino library capable of detecting input events and reporing
+ * An Arduino library capable of detecting input events and reporting
  * consecutive button presses made in quick succession or if the 
  * button was held down for a long time. 
  * 
@@ -12,22 +12,30 @@
 
 #include "Arduino.h"
 
-// Assume we are dealing with a 2 byte IO value - i.e. 16 binary inputs
-// typically from an MCP23017 I2C I/O buffer chip
-#define USM_INPUT_COUNT           16
-
 // DEBOUNCE times (adjust these if you have very noisy buttons or switches)
-//  * BUTTON types need short debounce times so we don't miss fast multi-click events
-#define USM_BTN_DEBOUNCE_LOW_MS   15      // delay to debounce the make part of the signal
-#define USM_BTN_DEBOUNCE_HIGH_MS  30      // delay to debounce the break part of the signal
-//  * OTHER types can have longer debounce times as we only need to detect simple transitions
-#define USM_OTH_DEBOUNCE_LOW_MS   50      // delay to debounce the make part of the signal
-#define USM_OTH_DEBOUNCE_HIGH_MS  100     // delay to debounce the break part of the signal
+//  USM_XXX_DEBOUNCE_LOW_MS       debounce delay for the MAKE part of the signal
+//  USM_XXX_DEBOUNCE_HIGH_MS      debounce delay for the BREAK part of the signal
+
+// BUTTON types need short debounce times so we don't miss fast multi-click events
+#define USM_BTN_DEBOUNCE_LOW_MS   15
+#define USM_BTN_DEBOUNCE_HIGH_MS  30
+
+// ROTARY types need short debounce times so we don't miss rapid rotations
+#define USM_ROT_DEBOUNCE_LOW_MS   15
+#define USM_ROT_DEBOUNCE_HIGH_MS  30
+
+// OTHER types can have longer debounce times as we only need to detect simple transitions
+#define USM_OTH_DEBOUNCE_LOW_MS   50
+#define USM_OTH_DEBOUNCE_HIGH_MS  100
 
 // BUTTON types need a few extra times for multi-click and hold event detection
 #define USM_BTN_MULTI_CLICK_MS    200     // how long to wait for another click before sending a multi-click event
 #define USM_BTN_HOLD_MS           500     // how long before a click is considered a HOLD event (and repeated)
 #define USM_BTN_MAX_CLICKS        5       // max count reported in a multi-click event
+
+// Assume we are dealing with a 2 byte IO value - i.e. 16 binary inputs
+// typically from an MCP23017 I2C I/O buffer chip
+#define USM_INPUT_COUNT           16
 
 // Event constants
 #define USM_NO_EVENT              0

--- a/Firmware/USMArduinoFirmware/USM_Input.h
+++ b/Firmware/USMArduinoFirmware/USM_Input.h
@@ -12,24 +12,28 @@
 
 #include "Arduino.h"
 
-// Hardcoded to save memory - should be configurable really
-// All times in milliseconds
-#define USM_DEBOUNCE_LOW_TIME     15      // delay to debounce the make part of the signal
-#define USM_DEBOUNCE_HIGH_TIME    30      // delay to debounce the break part of the signal
-#define USM_MULTI_CLICK_TIME      200     // if 0, does not check for multiple button clicks
-#define USM_HOLD_TIME             500     // how often a HOLD event is sent while a button is long-pressed
-
-// Assume we are dealing with a 2 byte IO value - i.e. 16 buttons
+// Assume we are dealing with a 2 byte IO value - i.e. 16 binary inputs
+// typically from an MCP23017 I2C I/O buffer chip
 #define USM_INPUT_COUNT           16
+
+// DEBOUNCE times (adjust these if you have very noisy buttons or switches)
+//  * BUTTON types need short debounce times so we don't miss fast multi-click events
+#define USM_BTN_DEBOUNCE_LOW_MS   15      // delay to debounce the make part of the signal
+#define USM_BTN_DEBOUNCE_HIGH_MS  30      // delay to debounce the break part of the signal
+//  * OTHER types can have longer debounce times as we only need to detect simple transitions
+#define USM_OTH_DEBOUNCE_LOW_MS   50      // delay to debounce the make part of the signal
+#define USM_OTH_DEBOUNCE_HIGH_MS  100     // delay to debounce the break part of the signal
+
+// BUTTON types need a few extra times for multi-click and hold event detection
+#define USM_BTN_MULTI_CLICK_MS    200     // how long to wait for another click before sending a multi-click event
+#define USM_BTN_HOLD_MS           500     // how long before a click is considered a HOLD event (and repeated)
+#define USM_BTN_MAX_CLICKS        5       // max count reported in a multi-click event
 
 // Event constants
 #define USM_NO_EVENT              0
 #define USM_HOLD_EVENT            15
 #define USM_LOW                   14
 #define USM_HIGH                  13
-
-// Max number of clicks we support (won't report more even if button clicked more often)
-#define USM_MAX_CLICKS            5
 
 // Rotary encoder state variables
 #define USM_R_START               0x0
@@ -151,6 +155,9 @@ class USM_Input
 
     // Private methods
     uint8_t _getValue(uint16_t value, uint8_t input);
+    uint16_t _getDebounceLowTime(uint8_t type);
+    uint16_t _getDebounceHighTime(uint8_t type);
+    
     void _update(uint8_t state[], uint16_t value);
 };
 


### PR DESCRIPTION
@moinmoin-sh if you wouldn't mind casting you eye over this one please?

Added the ability to adjust the debounce times, on an input type basis (rather than global or per individual input). Currently just different times for BUTTON and ROTARY vs all other types.

I am hopeful this will be a reasonable middleground, allowing for simple SWITCH/CONTACT inputs to be a bit more robust in their debounce checks, but BUTTON and ROTARY inputs still operate fast enough to allow accurate multi-click detection.