### PR TITLE
improve mcp scanning

### DIFF
--- a/Firmware/USMArduinoFirmware/USM_Input.cpp
+++ b/Firmware/USMArduinoFirmware/USM_Input.cpp
@@ -54,13 +54,13 @@ void USM_Input::setType(uint8_t input, uint8_t type)
 uint8_t USM_Input::getInvert(uint8_t input)
 {
   // shifts the desired 1 bit to the right most position then masks the LSB
-  return (_usmInvert >> input) & 0x01L;
+  return (_usmInvert >> input) & 0x01;
 }
 
 void USM_Input::setInvert(uint8_t input, uint8_t invert)
 {
   // sets a mask with the 1 bit we want to change to 0  
-  uint16_t mask = ~(0x01L << input);
+  uint16_t mask = ~(0x01 << input);
   // '& mask' clears, then '| (..)' sets the desired type at desired location 
   _usmInvert = (_usmInvert & mask) | ((uint16_t)invert << input);
 }
@@ -92,9 +92,7 @@ void USM_Input::process(uint8_t id, uint16_t value)
 
 uint8_t USM_Input::_getValue(uint16_t value, uint8_t input)
 {
-  uint8_t bit = bitRead(value, input);
-  if (getInvert(input)) { bit = !bit; }
-  return bit;
+  return (bitRead(value, input) ^ getInvert(input));
 }
 
 uint16_t USM_Input::_getDebounceLowTime(uint8_t type)


### PR DESCRIPTION
this fixes a long standing problem if you have MCPs on non-sequential addresses and a `MCP_MAX_COUNT` if < 8 - should now scan and initialise any number of MCPs on any set of addresses.